### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Install : you can install the BiotypeR package from GitHub using `devtools` pack
     require(devtools)
     install_github("tapj/BiotypeR")
     library(BiotypeR)
-    example(BiotypeR)
+    data(Titanium16S)
+    Titanium16S.biotypes=biotyper.data.frame(Titanium16S, k=3, manalysis=TRUE)
     
   
   


### PR DESCRIPTION
example(BiotypeR)

BitypR> data(Titanium16S)

BitypR> Titanium16S.biotypes=biotyper(Titanium16S, k=3, manalysis=TRUE)
Error in UseMethod("biotyper") : 
  no applicable method for 'biotyper' applied to an object of class "data.frame"